### PR TITLE
Define responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ let result = interpreter.parse_schema(
         security: "jwt_auth", 
         method: "post", 
         summary: "Update a user", 
-        description: "Update a user" 
+        description: "Update a user",
+        responses: {
+            200: createResponseObject("Return the updated user", 200, {"id": {"type":"string"}, "name": {"type":"string"}})
+        }
     })
 )
 console.log(JSON.stringify(result))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yup-to-swagger-tool",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Made the interpreter like it was made before since it breaks following the examples.
The responses are made like pure json object since usually there is no need to validate the return of an api through openApi